### PR TITLE
Fix age calculation and auricular surface logic

### DIFF
--- a/src/utils/analyzer/DefaultAnalyzerStrategy.ts
+++ b/src/utils/analyzer/DefaultAnalyzerStrategy.ts
@@ -830,8 +830,8 @@ export class DefaultAnalyzerStrategy extends AbstractAnalyzer {
         const [S4, S5, S6] = getAuricularSurfaceValues(data2);
 
         results[Report.auricularSurface][`${side}`] = this.average(S1, S4);
-        results[Report.auricularSurface][`${side}_min`] = Math.min(S2, S3);
-        results[Report.auricularSurface][`${side}_max`] = Math.max(S5, S6);
+        results[Report.auricularSurface][`${side}_min`] = Math.min(S2, S5);
+        results[Report.auricularSurface][`${side}_max`] = Math.max(S3, S6);
     }
 
     /**

--- a/src/views/ReportPageView.ts
+++ b/src/views/ReportPageView.ts
@@ -262,12 +262,15 @@ export class ReportPageView extends AbstractView {
      */
     private calculateSummarizedRange(report: AbstractReportModel): string {
         // Get the minimum and maximum age across all ranges
-        const minAge = Math.min(
-            report.getPubicSymphysisRange(Side.C).min,
-            report.getAuricularSurfaceRange(Side.C).min,
-            report.getSternalEndRange(Side.C).min,
-        ).toFixed(2);
-
+        if ((report as ReportModel).getThirdMolar(Side.C) === 0) {
+            var minAge = Math.min(
+                report.getPubicSymphysisRange(Side.C).min,
+                report.getAuricularSurfaceRange(Side.C).min,
+                report.getSternalEndRange(Side.C).min,
+            ).toFixed(2);
+        } else {
+            var minAge = '18.00';
+        }
         const maxAge = Math.max(
             report.getPubicSymphysisRange(Side.C).max,
             report.getAuricularSurfaceRange(Side.C).max,


### PR DESCRIPTION
Adjust the minimum age to 18 when certain conditions are met and correct the auricular surface calculations for accuracy. Address various bug fixes to improve overall functionality.